### PR TITLE
Update for compatibility with GHC-7.10.

### DIFF
--- a/Language/Paraiso/Failure.hs
+++ b/Language/Paraiso/Failure.hs
@@ -3,10 +3,10 @@
 -- | a module for handling failure
 module Language.Paraiso.Failure
     (
-     module Control.Monad.Failure, unsafePerformFailure
+     module Control.Failure, unsafePerformFailure
     ) where
 
-import Control.Monad.Failure
+import Control.Failure
 import System.IO.Unsafe
 
 unsafePerformFailure :: IO a -> a

--- a/Language/Paraiso/Tuning/Genetic.hs
+++ b/Language/Paraiso/Tuning/Genetic.hs
@@ -173,8 +173,10 @@ overwriteGenome dna oldSpec =
 
 
 
-newtype Get a = Get { getGet :: State.State [Bool] a } deriving (Monad)
-newtype Put a = Put { getPut :: State.State [Bool] a } deriving (Monad)
+newtype Get a = Get { getGet :: State.State [Bool] a }
+    deriving (Prelude.Functor, Prelude.Applicative, Monad)
+newtype Put a = Put { getPut :: State.State [Bool] a }
+    deriving (Prelude.Functor, Prelude.Applicative, Monad)
 
 get :: Get Bool
 get = Get $ do

--- a/Paraiso.cabal
+++ b/Paraiso.cabal
@@ -149,7 +149,7 @@ Library
   Build-depends:       array                 >= 0.2    ,    
                        base                  == 4.*    ,
                        containers            >= 0.4.0  ,
-                       control-monad-failure >= 0.7.0  ,
+                       failure               >= 0.1.0  ,
                        directory             >= 1.0    ,
                        filepath              >= 1.2.0  ,
                        fgl                   >= 5.4.2  ,


### PR DESCRIPTION
This version of GHC, due to [AMP](https://wiki.haskell.org/Functor-Applicative-Monad_Proposal), requires that every monad be also `Functor` and `Applicative`.

Also, the `control-monad-failure` package isn't supported anymore; the module `Control.Monad.Failure` can be easily replaced with `Control.Failure` from the `failure` package.

(In fact, the latest version of `control-monad-failure` [only linked to that package, anyway](http://hackage.haskell.org/package/control-monad-failure-0.7.0.1/docs/Control-Monad-Failure.html)!)