### PR TITLE
Compiling with GHC8

### DIFF
--- a/Language/Paraiso/Generator/ClarisTrans.hs
+++ b/Language/Paraiso/Generator/ClarisTrans.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE CPP, FlexibleContexts, ImpredicativeTypes, NoImplicitPrelude,
+{-# LANGUAGE CPP, FlexibleContexts, NoImplicitPrelude,
 MultiParamTypeClasses, OverloadedStrings,
 RankNTypes #-}
 

--- a/Language/Paraiso/OM/Builder/Boolean.hs
+++ b/Language/Paraiso/OM/Builder/Boolean.hs
@@ -35,7 +35,7 @@ mkOp2B op builder1 builder2 = do
   return $ FromNode r1 True n01
 
 
-type CompareOp =  (TRealm r, Typeable c) => 
+type CompareOp = forall r c v g a. (TRealm r, Typeable c) => 
     (Builder v g a (Value r c)) -> (Builder v g a (Value r c)) -> (Builder v g a (Value r Bool))
 
 -- | Equal

--- a/Paraiso.cabal
+++ b/Paraiso.cabal
@@ -16,7 +16,7 @@ Name:                Paraiso
 -- (http://www.haskell.org/haskellwiki/Package_versioning_policy) for
 -- standards guiding when and how versions should be incremented.
 Version:             0.3.1.5
-Tested-With:         GHC==7.4.1
+Tested-With:         GHC==8.0.1,GHC==7.4.1
 
 -- A short (one-line) description of the package.
 Synopsis:            a code generator for partial differential equations solvers.
@@ -203,5 +203,9 @@ test-suite runtests
                      HUnit,
                      QuickCheck >= 2
   main-is: runtests.hs
+  other-modules:     Test.Paraiso.Annotation
+                     Test.Paraiso.Claris
+                     Test.Paraiso.QuickCheckItself
+
   ghc-options:     -Wall -O3  -fspec-constr-count=25
   Default-Language: Haskell2010


### PR DESCRIPTION
Some changes made for compatibility with GHC 8, following some of https://ghc.haskell.org/trac/ghc/wiki/Migration/8.0 , it builds and passes tests normally.

Also added the test modules for adequate building in Hackage. Maybe the version should be changed? I'm not sure it still builds with GHC 7.10, I have no means to test it at this moment.
